### PR TITLE
Use registry.k8s.io for csi-node-driver-registrar image

### DIFF
--- a/deploy/charts/cluster-config-maps/Chart.yaml
+++ b/deploy/charts/cluster-config-maps/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-config-maps
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.0

--- a/deploy/charts/cluster-config-maps/templates/daemonset.yaml
+++ b/deploy/charts/cluster-config-maps/templates/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/

Pull the same version of csi-node-driver-registrar but from the new recommended registry.

Confirmed that the image we're referencing is present in registry.k8s.io using:
```bash
crane manifest 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0'
```
